### PR TITLE
refactor: wrap auth pages (except profile) in <AuthLayout>

### DIFF
--- a/src/features/auth/components/AuthForm.module.css
+++ b/src/features/auth/components/AuthForm.module.css
@@ -1,3 +1,9 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 .error {
   background-color: rgba(230, 0, 0, 0.2);
   border: 1px solid #e60000;

--- a/src/features/auth/components/AuthLayout/AuthLayout.module.css
+++ b/src/features/auth/components/AuthLayout/AuthLayout.module.css
@@ -1,0 +1,8 @@
+.container {
+  max-width: 450px;
+  margin: 0 auto;
+  padding: 48px;
+  background: var(--spotify-dark-elevated);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}

--- a/src/features/auth/pages/AuthPages.module.css
+++ b/src/features/auth/pages/AuthPages.module.css
@@ -16,14 +16,8 @@
   letter-spacing: -0.04em;
 }
 
-.form {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
 .divider {
-  margin: 24px 0;
+  margin: 24px 0px 0px;
   text-align: center;
   position: relative;
 }
@@ -47,19 +41,4 @@
   text-transform: uppercase;
   font-weight: 700;
   letter-spacing: 1px;
-}
-
-.forgotPasswordLink {
-  display: block;
-  text-align: center;
-  color: var(--spotify-white);
-  font-size: 14px;
-  font-weight: 700;
-  text-decoration: underline;
-  margin-top: 16px;
-  transition: color 0.2s ease;
-}
-
-.forgotPasswordLink:hover {
-  color: var(--spotify-green);
 }

--- a/src/features/auth/pages/LoginPage/LoginPage.module.css
+++ b/src/features/auth/pages/LoginPage/LoginPage.module.css
@@ -1,0 +1,15 @@
+
+.forgotPasswordLink {
+  display: block;
+  text-align: center;
+  color: var(--spotify-white);
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: underline;
+  margin-top: 16px;
+  transition: color 0.2s ease;
+}
+
+.forgotPasswordLink:hover {
+  color: var(--spotify-green);
+}

--- a/src/features/auth/pages/LoginPage/LoginPage.tsx
+++ b/src/features/auth/pages/LoginPage/LoginPage.tsx
@@ -1,7 +1,9 @@
-import { Link } from "react-router-dom";
-import { LoginForm } from "../../components/LoginForm/LoginForm";
+import { AuthLayout } from "@/features/auth";
+import { LoginForm } from "@/features/auth";
 import { AuthFormFooter } from "../../components/AuthFormFooter/AuthFormFooter";
-import styles from "./AuthPages.module.css";
+import { Link } from "react-router-dom";
+import styles from "./LoginPage.module.css";
+import authStyles from "../AuthPages.module.css";
 
 interface LoginPageProps {
   onSuccess: () => void;
@@ -9,27 +11,22 @@ interface LoginPageProps {
 
 export const LoginPage = ({ onSuccess }: LoginPageProps) => {
   return (
-    <>
-      <div className="app-header">
-        <h1 className="app-title">Music Player</h1>
+    <AuthLayout>
+      <LoginForm onSuccess={onSuccess} />
+
+      <Link to="/reset-password" className={styles.forgotPasswordLink}>
+        Forgot your password?
+      </Link>
+
+      <div className={authStyles.divider}>
+        <span>or</span>
       </div>
-      <div className={styles.container}>
-        <LoginForm onSuccess={onSuccess} />
 
-        <Link to="/reset-password" className={styles.forgotPasswordLink}>
-          Forgot your password?
-        </Link>
-
-        <div className={styles.divider}>
-          <span>or</span>
-        </div>
-
-        <AuthFormFooter
-          footerText="Don't have an account?"
-          linkText="Sign up for Spotify"
-          linkTo="/register"
-        />
-      </div>
-    </>
+      <AuthFormFooter
+        footerText="Don't have an account?"
+        linkText="Sign up for Spotify"
+        linkTo="/register"
+      />
+    </AuthLayout>
   );
 };

--- a/src/features/auth/pages/ProfilePage/ProfilePage.tsx
+++ b/src/features/auth/pages/ProfilePage/ProfilePage.tsx
@@ -1,9 +1,9 @@
 import { type JSX } from "react";
 import { useNavigate } from "react-router-dom";
 import { type UserProfile } from "../../types";
-import styles from "./ProfilePage.module.css";
 import defaultAvatar from "@/shared/assets/default_avatar.png";
 import { Button } from "@/shared/components";
+import styles from "./ProfilePage.module.css";
 
 interface ProfilePageProps {
   profile: UserProfile | null;

--- a/src/features/auth/pages/RegisterPage/RegisterPage.tsx
+++ b/src/features/auth/pages/RegisterPage/RegisterPage.tsx
@@ -1,6 +1,7 @@
 import { RegistrationForm } from "../../components/RegistrationForm/RegistrationForm";
 import { AuthFormFooter } from "../../components/AuthFormFooter/AuthFormFooter";
-import styles from "../LoginPage/AuthPages.module.css";
+import { AuthLayout } from "../../components/AuthLayout/AuthLayout";
+import authStyles from "../AuthPages.module.css";
 
 interface RegisterPageProps {
   onSuccess?: () => void;
@@ -9,13 +10,10 @@ interface RegisterPageProps {
 export const RegisterPage = ({ onSuccess }: RegisterPageProps) => {
   return (
     <>
-      <div className="app-header">
-        <h1 className="app-title">Music Player</h1>
-      </div>
-      <div className={styles.container}>
+      <AuthLayout>
         <RegistrationForm onSuccess={onSuccess} />
 
-        <div className={styles.divider}>
+        <div className={authStyles.divider}>
           <span>or</span>
         </div>
 
@@ -24,7 +22,7 @@ export const RegisterPage = ({ onSuccess }: RegisterPageProps) => {
           linkText="Log in to Spotify"
           linkTo="/login"
         />
-      </div>
+      </AuthLayout>
     </>
   );
 };

--- a/src/features/auth/pages/RequestResetPasswordPage/RequestResetPasswordPage.tsx
+++ b/src/features/auth/pages/RequestResetPasswordPage/RequestResetPasswordPage.tsx
@@ -1,6 +1,7 @@
 import { AuthFormFooter } from "../../components/AuthFormFooter/AuthFormFooter";
-import styles from "../LoginPage/AuthPages.module.css";
 import { RequestResetPasswordForm } from "../../components/RequestResetPasswordForm/RequestResetPasswordForm";
+import { AuthLayout } from "../../components/AuthLayout/AuthLayout";
+import authStyles from "../AuthPages.module.css";
 
 interface RequestResetPasswordPageProps {
   onSuccess: () => void;
@@ -11,20 +12,19 @@ export const RequestResetPasswordPage = ({
 }: RequestResetPasswordPageProps) => {
   return (
     <>
-      <div className="app-header">
-        <h1 className="app-title">Music Player</h1>
-      </div>
-      <div className={styles.container}>
+      <AuthLayout>
         <RequestResetPasswordForm onSuccess={onSuccess} />
 
-        <div className={styles.divider}></div>
+        <div className={authStyles.divider}>
+          <span>or</span>
+        </div>
 
         <AuthFormFooter
-          footerText="Sorted out your password?"
+          footerText="Remembered your password?"
           linkText="Go back to login"
           linkTo="/login"
         />
-      </div>
+      </AuthLayout>
     </>
   );
 };

--- a/src/features/auth/pages/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/src/features/auth/pages/ResetPasswordPage/ResetPasswordPage.tsx
@@ -1,6 +1,7 @@
 import { AuthFormFooter } from "../../components/AuthFormFooter/AuthFormFooter";
-import styles from "../LoginPage/AuthPages.module.css";
 import { ResetPasswordForm } from "../../components/ResetPasswordForm/ResetPasswordForm";
+import { AuthLayout } from "@/features/auth";
+import authStyles from "../AuthPages.module.css";
 
 interface ResetPasswordPageProps {
   onSuccess: () => void;
@@ -8,21 +9,18 @@ interface ResetPasswordPageProps {
 
 export const ResetPasswordPage = ({ onSuccess }: ResetPasswordPageProps) => {
   return (
-    <>
-      <div className="app-header">
-        <h1 className="app-title">Music Player</h1>
-      </div>
-      <div className={styles.container}>
-        <ResetPasswordForm onSuccess={onSuccess} />
+    <AuthLayout>
+      <ResetPasswordForm onSuccess={onSuccess} />
 
-        <div className={styles.divider}></div>
-
-        <AuthFormFooter
-          footerText="Sorted out your password?"
-          linkText="Go back to login"
-          linkTo="/login"
-        />
+      <div className={authStyles.divider}>
+        <span>or</span>
       </div>
-    </>
+
+      <AuthFormFooter
+        footerText="Sorted out your password?"
+        linkText="Go back to login"
+        linkTo="/login"
+      />
+    </AuthLayout>
   );
 };

--- a/src/features/auth/resetPassword.test.tsx
+++ b/src/features/auth/resetPassword.test.tsx
@@ -327,7 +327,7 @@ describe("Reset Password Features", () => {
       expect(screen.getByText(/Reset your password/i)).toBeInTheDocument();
       expect(screen.getByPlaceholderText("Email address")).toBeInTheDocument();
       expect(
-        screen.getByText(/Sorted out your password?/i),
+        screen.getByText(/Remembered your password?/i),
       ).toBeInTheDocument();
       expect(screen.getByText("Go back to login")).toBeInTheDocument();
     });


### PR DESCRIPTION
Wrap LoginPage, RegisterPage, RequestPasswordResetPage, PasswordResetPage in <AuthLayout> component (`src/features/auth/components/AuthLayout`) to reduce code duplication across the page components.

CSS moved from `AuthPages.module.css` into `AuthLayout.css` and `LoginPage.module.css` where appropriate. Imports fixed.

Subtitle for RequestPasswordResetPage changed from `Sorted out your password?` to `Remembered your password?`.
Tests fixed to reflect this.