### PR TITLE
feat: profile editing (username and avatar)

### DIFF
--- a/src/features/auth/api/index.ts
+++ b/src/features/auth/api/index.ts
@@ -7,6 +7,7 @@ export const login = async (email: string, password: string): Promise<void> => {
     body: JSON.stringify({ email, password }),
   });
 };
+
 export const getMe = async (): Promise<UserProfile> => {
   return await request("/auth/user/");
 };
@@ -52,6 +53,21 @@ export const confirmPasswordReset = async (
       token,
       new_password1,
       new_password2,
+    }),
+  });
+};
+
+export const updateProfile = async (
+  username: string,
+  avatar_url?: string,
+): Promise<UserProfile> => {
+
+  return await request("/auth/user/", {
+    method: "PATCH",
+    credentials: "include",
+    body: JSON.stringify({
+      username,
+      avatar_url,
     }),
   });
 };

--- a/src/features/auth/pages/ProfilePage/ProfilePage.module.css
+++ b/src/features/auth/pages/ProfilePage/ProfilePage.module.css
@@ -27,12 +27,30 @@
   font-weight: 700;
   color: var(--spotify-white);
   overflow: hidden;
+  position: relative;
 }
 
 .avatar img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.avatar .editOverlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: none;
+    color: #FFF;
+}
+.avatar:hover .editOverlay {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+    cursor: pointer;
 }
 
 .displayName {
@@ -90,4 +108,37 @@
   padding: 16px;
   border-radius: 4px;
   text-align: center;
+}
+
+.editActions {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  margin-top: 24px;
+}
+
+.editInfoValue {
+  width: 100%;
+  padding: 14px 16px;
+  background-color: #282828;;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--spotify-white);
+  font-size: 14px;
+  font-family: inherit;
+  transition: all 0.2s ease;
+}
+
+.editInfoValue:hover {
+  border-color: var(--spotify-gray-dark);
+}
+
+.editInfoValue:focus {
+  outline: none;
+  border-color: var(--spotify-white);
+  background-color: #282828;
+}
+
+.editInfoValue::placeholder {
+  color: var(--spotify-gray);
 }

--- a/src/features/auth/pages/ProfilePage/ProfilePage.tsx
+++ b/src/features/auth/pages/ProfilePage/ProfilePage.tsx
@@ -1,16 +1,68 @@
-import { type JSX } from "react";
+import { useEffect, useRef, useState, type ChangeEvent, type JSX } from "react";
 import { useNavigate } from "react-router-dom";
 import { type UserProfile } from "../../types";
 import defaultAvatar from "@/shared/assets/default_avatar.png";
 import { Button } from "@/shared/components";
 import styles from "./ProfilePage.module.css";
+import { PencilSolid } from "@/shared/icons";
+import { useCloudinaryUpload } from "@/shared/hooks";
+import { updateProfile } from "../../api";
 
 interface ProfilePageProps {
   profile: UserProfile | null;
+  isEditing?: boolean;
 }
 
-export const ProfilePage = ({ profile }: ProfilePageProps): JSX.Element => {
+export const ProfilePage = ({ profile, isEditing = false }: ProfilePageProps): JSX.Element => {
   const navigate = useNavigate();
+
+  const [newUsername, setNewUsername] = useState("");
+  const [newAvatarUrl, setNewAvatarUrl] = useState("");
+  const { upload, isUploading, error: uploadError } = useCloudinaryUpload();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!profile) return;
+    if (!isEditing) {
+      setNewUsername(profile.username ?? "");
+      setNewAvatarUrl(profile.avatar_url ?? "");
+    }
+  }, [isEditing, profile]);
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      await handleAvatarUpload(file);
+    }
+  };
+
+  const handleAvatarUpload = async (file: File) => {
+    try {
+      const cloudinaryResponse = await upload(file);
+      setNewAvatarUrl(cloudinaryResponse.secure_url);
+    } catch (err) {
+      console.error("New profile avatar upload failed:", err);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!profile) return;
+    try {
+      await updateProfile(newUsername || profile.username, newAvatarUrl);
+      navigate("/profile");
+    } catch (err) {
+      console.error("Failed to update profile:", err);
+    }
+  };
+
+  const handleCancel = () => {
+    if (profile) {
+      setNewUsername(profile.username ?? "");
+      setNewAvatarUrl(profile.avatar_url ?? "");
+    }
+    navigate("/profile");
+  };
+
 
   if (!profile) {
     return (
@@ -27,24 +79,51 @@ export const ProfilePage = ({ profile }: ProfilePageProps): JSX.Element => {
 
   const username = profile.username;
   const avatarUrl = profile.avatar_url;
+  const displayAvatarUrl = newAvatarUrl || avatarUrl;
 
   return (
     <div className={styles.container}>
       <div className={styles.card}>
         <div className={styles.avatarSection}>
           <div className={styles.avatar}>
-            {avatarUrl ? (
-              <img src={avatarUrl} alt="Profile" />
+            { isEditing && (
+              <div
+                className={styles.editOverlay}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <PencilSolid className={styles.editIcon} />
+              </div>
+            )}
+            {isEditing && (
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                style={{ display: "none" }}
+              />
+            )}
+            {displayAvatarUrl ? (
+              <img src={displayAvatarUrl} alt="Profile" />
             ) : (
               <img src={defaultAvatar} alt="Default Profile" />
             )}
           </div>
-          <h1 className={styles.displayName}>@{username}</h1>
+          <h1 className={styles.displayName}>{username}</h1>
+          {!isEditing && (
+            <Button variant="outlined" size="small" onClick={() => navigate("/profile/edit")}>
+              Edit Profile
+            </Button>
+          )}
         </div>
 
         <div className={styles.divider}></div>
 
         <div className={styles.infoSection}>
+          <div className={styles.infoLabel}>Username</div>
+          {isEditing ?
+            (<input className={styles.editInfoValue} placeholder={`${username}`} value={newUsername} onChange={(e) => setNewUsername(e.target.value)} />)
+            : (<div className={styles.infoValue}>{username}</div>)}
           <div className={styles.infoLabel}>Email</div>
           <div className={styles.infoValue}>{profile.email}</div>
 
@@ -52,9 +131,23 @@ export const ProfilePage = ({ profile }: ProfilePageProps): JSX.Element => {
           <div className={styles.infoValue}>#{profile.id}</div>
         </div>
 
-        <Button variant="outlined" size="large" onClick={() => navigate("/")}>
-          Back to Home
-        </Button>
+        {isEditing ? (
+          <div className={styles.editActions}>
+            <Button variant="outlined" size="large" onClick={handleSave} disabled={isUploading}>
+              Save
+            </Button>
+            <Button variant="outlined" size="large" onClick={handleCancel}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button variant="outlined" size="large" onClick={() => navigate("/")}>
+            Back to Home
+          </Button>
+        )}
+        {uploadError && (
+          <div className={styles.error}>{String(uploadError)}</div>
+        )}
       </div>
     </div>
   );

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -43,12 +43,14 @@ export const AppRoutes = ({
           )
         }
       />
+
       <Route
         path="/register"
         element={
           isAuthenticated ? <Navigate to="/" replace /> : <RegisterPage />
         }
       />
+
       <Route
         path="/reset-password"
         element={
@@ -69,6 +71,7 @@ export const AppRoutes = ({
           </ProtectedRoute>
         }
       />
+
       <Route
         path="/upload"
         element={
@@ -81,11 +84,20 @@ export const AppRoutes = ({
           </ProtectedRoute>
         }
       />
+
       <Route
         path="/profile"
         element={
           <ProtectedRoute isAuthenticated={isAuthenticated}>
             <ProfilePage profile={userProfile} />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/profile/edit"
+        element={
+          <ProtectedRoute isAuthenticated={isAuthenticated}>
+            <ProfilePage profile={userProfile} isEditing={true} />
           </ProtectedRoute>
         }
       />

--- a/src/shared/icons/PencilSolid.tsx
+++ b/src/shared/icons/PencilSolid.tsx
@@ -1,0 +1,18 @@
+import type { SVGProps } from "react";
+
+export function PencilSolid(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        d="M21.731 2.269a2.625 2.625 0 0 0-3.712 0l-1.157 1.157l3.712 3.712l1.157-1.157a2.625 2.625 0 0 0 0-3.712m-2.218 5.93l-3.712-3.712l-12.15 12.15a5.25 5.25 0 0 0-1.32 2.214l-.8 2.685a.75.75 0 0 0 .933.933l2.685-.8a5.25 5.25 0 0 0 2.214-1.32z"
+      ></path>
+    </svg>
+  )
+}

--- a/src/shared/icons/index.ts
+++ b/src/shared/icons/index.ts
@@ -4,3 +4,4 @@ export { ButtonPlaySolid } from "./ButtonPlaySolid";
 export { ButtonPreviousSolid } from "./ButtonPreviousSolid";
 export { BubbleLoading as LoadingAnimation } from "./LoadingAnimation";
 export { MoreHorizontalOutline } from "./MoreHorizontalOutline";
+export { PencilSolid } from "./PencilSolid";


### PR DESCRIPTION
Users can now edit their avatar and username easily from their profile. Managing email is not possible, this is currently out of scope but may be changed later on as django_rest_auth does provide this. 