### PR TITLE
Fix: collaborative playlist toggle

### DIFF
--- a/src/features/playlists/components/CreateNewPlaylistForm/CreateNewPlaylistForm.test.tsx
+++ b/src/features/playlists/components/CreateNewPlaylistForm/CreateNewPlaylistForm.test.tsx
@@ -57,19 +57,21 @@ describe("CreateNewPlaylistForm", () => {
       await user.type(screen.getByLabelText("Description"), "Coding playlist");
 
       await user.click(screen.getByLabelText("Public"));
-
       await user.click(screen.getByLabelText("Collaborative"));
 
       await user.click(screen.getByRole("button", { name: "Create Playlist" }));
 
       await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalledWith({
-          title: "Focus Flow",
-          description: "Coding playlist",
-          cover_art_url: "",
-          is_public: false,
-          is_collaborative: true,
-        });
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: "Focus Flow",
+            description: "Coding playlist",
+            cover_art_url: "",
+            is_public: true,
+            is_collaborative: true,
+          }),
+          expect.anything(),
+        );
       });
     });
   });
@@ -77,7 +79,6 @@ describe("CreateNewPlaylistForm", () => {
   describe("UI States", () => {
     it("disables submit and changes button text while submitting", () => {
       render(<CreateNewPlaylistForm onSubmit={vi.fn()} isSubmitting={true} />);
-
       const button = screen.getByRole("button", { name: "Creating..." });
       expect(button).toBeDisabled();
     });
@@ -88,9 +89,7 @@ describe("CreateNewPlaylistForm", () => {
         isUploading: true,
         error: null,
       });
-
       render(<CreateNewPlaylistForm onSubmit={vi.fn()} />);
-
       const button = screen.getByRole("button", { name: "Create Playlist" });
       expect(button).toBeDisabled();
       expect(screen.getByText("Uploading…")).toBeInTheDocument();
@@ -102,18 +101,47 @@ describe("CreateNewPlaylistForm", () => {
         isUploading: false,
         error: "Upload failed",
       });
-
       render(
         <CreateNewPlaylistForm
           onSubmit={vi.fn()}
           error="Could not save playlist"
         />,
       );
-
       expect(screen.getByText("Could not save playlist")).toBeInTheDocument();
       expect(
         screen.getByText("Cover Art Error: Upload failed"),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("Visibility and Toggles", () => {
+    it("hides the collaborative checkbox when public is false", () => {
+      render(<CreateNewPlaylistForm onSubmit={vi.fn()} />);
+      expect(screen.queryByLabelText("Collaborative")).not.toBeInTheDocument();
+    });
+
+    it("resets collaborative to false and hides it when public is unchecked", async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+      render(<CreateNewPlaylistForm onSubmit={onSubmit} />);
+
+      await user.type(screen.getByLabelText("Title"), "My Playlist");
+      await user.click(screen.getByLabelText("Public"));
+      await user.click(screen.getByLabelText("Collaborative"));
+      await user.click(screen.getByLabelText("Public"));
+
+      expect(screen.queryByLabelText("Collaborative")).not.toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Create Playlist" }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            is_public: false,
+            is_collaborative: false,
+          }),
+          expect.anything(),
+        );
+      });
     });
   });
 
@@ -126,17 +154,13 @@ describe("CreateNewPlaylistForm", () => {
       const onSubmit = vi.fn();
 
       render(<CreateNewPlaylistForm onSubmit={onSubmit} />);
-
       const fileInput = screen.getByLabelText(
         "Upload Cover Art",
       ) as HTMLInputElement;
       const file = new File(["cover"], "cover.jpg", { type: "image/jpeg" });
 
       await user.upload(fileInput, file);
-
-      await waitFor(() => {
-        expect(mockUpload).toHaveBeenCalledWith(file);
-      });
+      await waitFor(() => expect(mockUpload).toHaveBeenCalledWith(file));
 
       await user.type(screen.getByLabelText("Title"), "Artful Mix");
       await user.click(screen.getByRole("button", { name: "Create Playlist" }));
@@ -147,19 +171,17 @@ describe("CreateNewPlaylistForm", () => {
             title: "Artful Mix",
             cover_art_url: "https://img.example.com/cover.png",
           }),
+          expect.anything(),
         );
       });
     });
 
     it("does not call upload when no file is selected", () => {
       render(<CreateNewPlaylistForm onSubmit={vi.fn()} />);
-
       const fileInput = screen.getByLabelText(
         "Upload Cover Art",
       ) as HTMLInputElement;
-
       fireEvent.change(fileInput, { target: { files: [] } });
-
       expect(mockUpload).not.toHaveBeenCalled();
     });
 
@@ -169,17 +191,13 @@ describe("CreateNewPlaylistForm", () => {
       const onSubmit = vi.fn();
 
       render(<CreateNewPlaylistForm onSubmit={onSubmit} />);
-
       const fileInput = screen.getByLabelText(
         "Upload Cover Art",
       ) as HTMLInputElement;
       const file = new File(["cover"], "cover.jpg", { type: "image/jpeg" });
 
       await user.upload(fileInput, file);
-
-      await waitFor(() => {
-        expect(mockUpload).toHaveBeenCalledWith(file);
-      });
+      await waitFor(() => expect(mockUpload).toHaveBeenCalledWith(file));
 
       await user.type(screen.getByLabelText("Title"), "Fallback Playlist");
       await user.click(screen.getByRole("button", { name: "Create Playlist" }));
@@ -187,6 +205,7 @@ describe("CreateNewPlaylistForm", () => {
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
           expect.objectContaining({ cover_art_url: "" }),
+          expect.anything(),
         );
       });
     });

--- a/src/features/playlists/components/CreateNewPlaylistForm/CreateNewPlaylistForm.tsx
+++ b/src/features/playlists/components/CreateNewPlaylistForm/CreateNewPlaylistForm.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useForm } from "react-hook-form";
+import { useRef } from "react";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { playlistSchema, type PlaylistFormValues } from "./schema";
 import styles from "@/features/songs/components/SongUploadForm/SongUploadForm.module.css";
@@ -7,13 +7,7 @@ import { useCloudinaryUpload } from "@/shared/hooks/useCloudinaryUpload";
 import { AlertMessage } from "@/shared/components";
 
 interface CreateNewPlaylistFormProps {
-  onSubmit: (values: {
-    title: string;
-    description: string;
-    is_public: boolean;
-    cover_art_url: string;
-    is_collaborative: boolean;
-  }) => void;
+  onSubmit: (values: PlaylistFormValues) => void;
   isSubmitting?: boolean;
   error?: string | null;
 }
@@ -23,8 +17,7 @@ export const CreateNewPlaylistForm = ({
   isSubmitting = false,
   error,
 }: CreateNewPlaylistFormProps) => {
-  const [coverArtUrl, setCoverArtUrl] = useState<string>("");
-  const [coverFileName, setCoverFileName] = useState<string>("");
+  const coverInputRef = useRef<HTMLInputElement>(null);
 
   const {
     upload: uploadCover,
@@ -35,72 +28,82 @@ export const CreateNewPlaylistForm = ({
   const {
     register,
     handleSubmit,
+    setValue,
+    control,
     formState: { errors },
   } = useForm<PlaylistFormValues>({
     resolver: zodResolver(playlistSchema),
     defaultValues: {
       title: "",
       description: "",
-      is_public: true,
+      is_public: false,
       is_collaborative: false,
+      cover_art_url: "",
     },
   });
 
-  const onFormSubmit = (data: PlaylistFormValues) => {
-    onSubmit({
-      title: data.title,
-      description: data.description || "",
-      is_public: data.is_public,
-      is_collaborative: data.is_collaborative,
-      cover_art_url: coverArtUrl,
-    });
-  };
+  // Watch the form state directly.
+  const isPublic = useWatch({ control, name: "is_public" });
+  const coverUrl = useWatch({ control, name: "cover_art_url" });
 
-  const handleCoverArtUpload = async (file: File | null) => {
+  const handleCoverChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
     if (!file) return;
-    setCoverFileName(file.name);
+
     try {
       const cloudData = await uploadCover(file);
       if (cloudData) {
-        setCoverArtUrl(cloudData.secure_url);
+        setValue("cover_art_url", cloudData.secure_url, { shouldDirty: true });
       }
     } catch (err) {
       console.error("Cover art upload failed:", err);
-      setCoverFileName("");
     }
   };
 
   return (
-    <form className={styles.container} onSubmit={handleSubmit(onFormSubmit)}>
+    <form className={styles.container} onSubmit={handleSubmit(onSubmit)}>
       <h3 className={styles.title}>Playlist Details</h3>
       <AlertMessage message={error} />
       <AlertMessage
         message={coverError ? `Cover Art Error: ${coverError}` : null}
       />
 
-      <div className={styles.fileUploadWrapper}>
-        <label
-          className={`${styles.uploadLabel} ${isCoverUploading ? styles.uploading : ""}`}
+      <div
+        className={styles.fileUploadWrapper}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "10px",
+        }}
+      >
+        <img
+          src={coverUrl || "https://placehold.co/220"}
+          alt="Playlist cover preview"
+          style={{
+            width: "150px",
+            height: "150px",
+            objectFit: "cover",
+            borderRadius: "8px",
+          }}
+        />
+        <button
+          type="button"
+          onClick={() => coverInputRef.current?.click()}
+          disabled={isCoverUploading}
+          style={{ cursor: "pointer" }}
         >
-          {isCoverUploading
-            ? "Uploading…"
-            : coverFileName
-              ? "✓ Change Cover"
-              : "Upload Cover Art"}
-          <input
-            aria-label="Upload Cover Art"
-            type="file"
-            accept="image/*"
-            className={styles.fileInput}
-            disabled={isCoverUploading}
-            onChange={(e) => handleCoverArtUpload(e.target.files?.[0] || null)}
-          />
-        </label>
-        {coverFileName && !isCoverUploading && (
-          <span className={`${styles.fileStatusText} ${styles.ready}`}>
-            ✓ {coverFileName}
-          </span>
-        )}
+          {isCoverUploading ? "Uploading…" : "Upload Cover Art"}
+        </button>
+        <input
+          ref={coverInputRef}
+          type="file"
+          accept="image/*"
+          style={{ display: "none" }}
+          onChange={handleCoverChange}
+          aria-label="Upload Cover Art"
+          tabIndex={-1}
+        />
       </div>
 
       <div className={styles.inputGroup}>
@@ -132,24 +135,39 @@ export const CreateNewPlaylistForm = ({
           type="checkbox"
           id="is_public"
           className={styles.checkbox}
-          {...register("is_public")}
+          {...register("is_public", {
+            onChange: (e) => {
+              // Force collaborative off if public is unchecked.
+              if (!e.target.checked) {
+                setValue("is_collaborative", false, { shouldValidate: true });
+              }
+            },
+          })}
         />
         <label htmlFor="is_public" className={styles.checkboxLabel}>
           Public
         </label>
       </div>
 
-      <div className={styles.checkboxContainer}>
-        <input
-          type="checkbox"
-          id="is_collaborative"
-          className={styles.checkbox}
-          {...register("is_collaborative")}
-        />
-        <label htmlFor="is_collaborative" className={styles.checkboxLabel}>
-          Collaborative
-        </label>
-      </div>
+      {isPublic && (
+        <div className={styles.checkboxContainer}>
+          <input
+            type="checkbox"
+            id="is_collaborative"
+            className={styles.checkbox}
+            {...register("is_collaborative")}
+          />
+          <label htmlFor="is_collaborative" className={styles.checkboxLabel}>
+            Collaborative
+          </label>
+        </div>
+      )}
+
+      {errors.is_collaborative && (
+        <span className={styles.errorText}>
+          {errors.is_collaborative.message}
+        </span>
+      )}
 
       <button
         type="submit"

--- a/src/features/playlists/components/CreateNewPlaylistForm/schema.ts
+++ b/src/features/playlists/components/CreateNewPlaylistForm/schema.ts
@@ -1,10 +1,16 @@
 import { z } from "zod";
 
-export const playlistSchema = z.object({
-  title: z.string().min(1, "Playlist name is required"),
-  description: z.string().optional(),
-  is_public: z.boolean(),
-  is_collaborative: z.boolean(),
-});
+export const playlistSchema = z
+  .object({
+    title: z.string().min(1, "Playlist name is required"),
+    description: z.string().optional(),
+    is_public: z.boolean(),
+    is_collaborative: z.boolean(),
+    cover_art_url: z.string().optional(),
+  })
+  .refine((data) => !(data.is_collaborative && !data.is_public), {
+    message: "Private playlists cannot be collaborative",
+    path: ["is_collaborative"],
+  });
 
 export type PlaylistFormValues = z.infer<typeof playlistSchema>;

--- a/src/features/playlists/components/CreateNewPlaylistModal.tsx
+++ b/src/features/playlists/components/CreateNewPlaylistModal.tsx
@@ -26,7 +26,7 @@ export const CreateNewPlaylistModal = ({
   const createMutation = useMutation({
     mutationFn: (values: {
       title: string;
-      description: string;
+      description?: string;
       cover_art_url: string;
       is_collaborative: boolean;
       is_public: boolean;
@@ -56,7 +56,10 @@ export const CreateNewPlaylistModal = ({
       <CreateNewPlaylistForm
         onSubmit={(values) => {
           setFormError(null);
-          createMutation.mutate(values);
+          createMutation.mutate({
+            ...values,
+            cover_art_url: values.cover_art_url ?? "",
+          });
         }}
         isSubmitting={createMutation.isPending}
         error={formError}

--- a/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.module.css
+++ b/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.module.css
@@ -1,3 +1,10 @@
+/* ── Edit form row ───────────────────────────────────────────── */
+.editFormRow {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 24px;
+}
 .editFields {
   flex: 1;
   min-width: 200px;
@@ -109,7 +116,8 @@
 .toggleRow {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
+  gap: 16px;
   font-size: 0.88rem;
   color: rgba(255, 255, 255, 0.7);
   cursor: pointer;
@@ -126,6 +134,12 @@
   transition: background 0.25s;
   padding: 0;
   flex-shrink: 0;
+}
+
+.collaborativeToggle {
+  display: 'flex';
+  align-items: 'center';
+  gap: '8px';
 }
 
 .toggleOn {

--- a/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.module.css
+++ b/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.module.css
@@ -137,9 +137,9 @@
 }
 
 .collaborativeToggle {
-  display: 'flex';
-  align-items: 'center';
-  gap: '8px';
+  display: "flex";
+  align-items: "center";
+  gap: "8px";
 }
 
 .toggleOn {

--- a/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.test.tsx
+++ b/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.test.tsx
@@ -120,6 +120,51 @@ describe("EditPlaylistForm", () => {
   });
 
   describe("input interactions", () => {
+    it("hides the Collaborative toggle when public is false", () => {
+      renderForm({ ...basePlaylist, is_public: false });
+      expect(
+        screen.queryByRole("switch", { name: /toggle collaborative mode/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("resets collaborative to false and hides it when public is toggled off", async () => {
+      const user = userEvent.setup();
+
+      renderForm({ ...basePlaylist, is_public: true, is_collaborative: true });
+
+      const collabToggle = screen.getByRole("switch", {
+        name: /toggle collaborative mode/i,
+      });
+      expect(collabToggle).toHaveAttribute("aria-checked", "true");
+
+      // Toggle public off.
+      const publicToggle = screen.getByRole("switch", {
+        name: /toggle public visibility/i,
+      });
+      await user.click(publicToggle);
+
+      expect(
+        screen.queryByRole("switch", { name: /toggle collaborative mode/i }),
+      ).not.toBeInTheDocument();
+
+      let patchBody: Record<string, unknown> = {};
+      server.use(
+        http.patch(
+          "http://localhost:8000/api/playlists/1/",
+          async ({ request }) => {
+            patchBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(basePlaylist);
+          },
+        ),
+      );
+      await user.click(
+        screen.getByRole("button", { name: /save playlist changes/i }),
+      );
+      await waitFor(() => {
+        expect(patchBody.is_public).toBe(false);
+        expect(patchBody.is_collaborative).toBe(false);
+      });
+    });
     it("allows typing a new title", async () => {
       const user = userEvent.setup();
       renderForm();
@@ -271,6 +316,12 @@ describe("EditPlaylistForm", () => {
       const onClose = vi.fn();
       renderForm(basePlaylist, onClose);
 
+      // Make dirty
+      const titleInput = screen.getByRole("textbox", {
+        name: /playlist title/i,
+      });
+      await user.type(titleInput, " updated");
+
       await user.click(
         screen.getByRole("button", { name: /save playlist changes/i }),
       );
@@ -322,6 +373,12 @@ describe("EditPlaylistForm", () => {
       );
 
       renderForm();
+
+      const titleInput = screen.getByRole("textbox", {
+        name: /playlist title/i,
+      });
+      await user.type(titleInput, " changed");
+
       const saveBtn = screen.getByRole("button", {
         name: /save playlist changes/i,
       });
@@ -340,6 +397,12 @@ describe("EditPlaylistForm", () => {
 
       const onClose = vi.fn();
       renderForm(basePlaylist, onClose);
+
+      const titleInput = screen.getByRole("textbox", {
+        name: /playlist title/i,
+      });
+      await user.type(titleInput, " changed");
+
       await user.click(
         screen.getByRole("button", { name: /save playlist changes/i }),
       );
@@ -374,6 +437,49 @@ describe("EditPlaylistForm", () => {
       await user.click(screen.getByRole("button", { name: /cancel editing/i }));
       expect(patched).toBe(false);
     });
+
+    it("resets form state to initial values on cancel", async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      const titleInput = screen.getByRole("textbox", {
+        name: /playlist title/i,
+      });
+      const descInput = screen.getByRole("textbox", {
+        name: /playlist description/i,
+      });
+
+      await user.clear(titleInput);
+      await user.type(titleInput, "Changed Title");
+      await user.clear(descInput);
+      await user.type(descInput, "Changed Description");
+
+      await user.click(screen.getByRole("button", { name: /cancel editing/i }));
+
+      expect(titleInput).toHaveValue("My Playlist");
+      expect(descInput).toHaveValue("Original description");
+    });
+
+    it("closes the form without making an API call if no fields were changed", async () => {
+      const user = userEvent.setup();
+      let patched = false;
+      const onClose = vi.fn();
+
+      server.use(
+        http.patch("http://localhost:8000/api/playlists/1/", () => {
+          patched = true;
+          return HttpResponse.json(basePlaylist);
+        }),
+      );
+
+      renderForm(basePlaylist, onClose);
+      await user.click(
+        screen.getByRole("button", { name: /save playlist changes/i }),
+      );
+
+      expect(onClose).toHaveBeenCalledOnce();
+      expect(patched).toBe(false);
+    });
   });
 
   describe("payload shape", () => {
@@ -391,6 +497,12 @@ describe("EditPlaylistForm", () => {
       );
 
       renderForm({ ...basePlaylist, cover_art_url: null });
+      const titleInput = screen.getByRole("textbox", {
+        name: /playlist title/i,
+      });
+      await user.clear(titleInput);
+      await user.type(titleInput, "Updated Title");
+
       await user.click(
         screen.getByRole("button", { name: /save playlist changes/i }),
       );
@@ -415,13 +527,28 @@ describe("EditPlaylistForm", () => {
       );
 
       renderForm();
+      const fileInput = screen.getByLabelText(/upload cover image file/i);
+      const file = new File(["dummy"], "photo.jpg", { type: "image/jpeg" });
+      mockUpload.mockResolvedValueOnce({
+        secure_url: "https://example.com/new-cover.png",
+      });
+
+      await user.upload(fileInput, file);
+
+      await waitFor(() =>
+        expect(screen.getByRole("img")).toHaveAttribute(
+          "src",
+          "https://example.com/new-cover.png",
+        ),
+      );
+
       await user.click(
         screen.getByRole("button", { name: /save playlist changes/i }),
       );
 
       await waitFor(() => {
         expect(patchBody.cover_art_url).toBe(
-          "https://example.com/original-cover.png",
+          "https://example.com/new-cover.png",
         );
       });
     });

--- a/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.tsx
+++ b/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.tsx
@@ -28,16 +28,13 @@ export const EditPlaylistForm = ({
   const queryClient = useQueryClient();
   const coverInputRef = useRef<HTMLInputElement>(null);
 
-  const [editCoverUrl, setEditCoverUrl] = useState(
-    playlist.cover_art_url ?? "",
-  );
-
   const {
     register,
     handleSubmit,
     control,
     setValue,
-    formState: { errors },
+    reset,
+    formState: { errors, dirtyFields },
   } = useForm<EditPlaylistFormValues>({
     resolver: zodResolver(editPlaylistSchema),
     defaultValues: {
@@ -45,20 +42,30 @@ export const EditPlaylistForm = ({
       description: playlist.description ?? "",
       is_public: playlist.is_public,
       is_collaborative: playlist.is_collaborative,
+      cover_art_url: playlist.cover_art_url ?? "https://placehold.co/220",
     },
   });
 
   const isPublic = useWatch({ control, name: "is_public" });
   const isCollaborative = useWatch({ control, name: "is_collaborative" });
+  const coverUrl = useWatch({ control, name: "cover_art_url" });
 
   const { upload: uploadCover, isUploading: isCoverUploading } =
     useCloudinaryUpload();
+
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmittingLocal, setIsSubmittingLocal] = useState(false);
 
   const handleCoverChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     const res = await uploadCover(file);
-    if (res) setEditCoverUrl(res.secure_url);
+    if (res) {
+      setValue("cover_art_url", res.secure_url, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+    }
   };
 
   const {
@@ -66,16 +73,8 @@ export const EditPlaylistForm = ({
     isPending: isSaving,
     error: saveError,
   } = useMutation({
-    mutationFn: (data: EditPlaylistFormValues) => {
-      const payload = {
-        title: data.title,
-        description: data.description,
-        is_public: data.is_public,
-        is_collaborative: data.is_collaborative,
-        ...(editCoverUrl ? { cover_art_url: editCoverUrl } : {}),
-      };
-      return updatePlaylist(playlist.id, payload);
-    },
+    mutationFn: (payload: Partial<EditPlaylistFormValues>) =>
+      updatePlaylist(playlist.id, payload),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.playlist(playlist.id),
@@ -85,22 +84,56 @@ export const EditPlaylistForm = ({
     },
   });
 
+  // Intercept the submission to filter out untouched fields
   const onFormSubmit = (data: EditPlaylistFormValues) => {
-    saveEdit(data);
+    const payload = Object.keys(dirtyFields).reduce((acc, key) => {
+      const k = key as keyof EditPlaylistFormValues;
+
+      (acc as Record<string, unknown>)[k] = data[k];
+
+      return acc;
+    }, {} as Partial<EditPlaylistFormValues>);
+
+    // If no fields were changed, close the form without making an API call.
+    if (Object.keys(payload).length === 0) {
+      onClose();
+      return;
+    }
+    setSubmitError(null);
+    setIsSubmittingLocal(true);
+
+    saveEdit(payload as Partial<EditPlaylistFormValues>, {
+      onError: (err: unknown) => {
+        setSubmitError(
+          err instanceof ApiError
+            ? err.getReadableMessage()
+            : err instanceof Error
+              ? err.message
+              : "An unexpected error occurred.",
+        );
+      },
+      onSettled: () => {
+        setIsSubmittingLocal(false);
+      },
+    });
   };
 
   const editErrorMessage =
-    saveError instanceof ApiError
+    submitError ??
+    (saveError instanceof ApiError
       ? saveError.getReadableMessage()
-      : saveError?.message || "An unexpected error occurred.";
+      : saveError?.message) ??
+    "An unexpected error occurred.";
 
   return (
     <form onSubmit={handleSubmit(onFormSubmit)}>
-      {saveError && <AlertMessage message={editErrorMessage} />}
+      {(saveError || submitError) && (
+        <AlertMessage message={editErrorMessage} />
+      )}
 
       <div className={styles.coverWrap}>
         <img
-          src={editCoverUrl || "https://placehold.co/220"}
+          src={coverUrl || "https://placehold.co/220"}
           alt="Playlist cover art"
           className={styles.coverArt}
         />
@@ -158,38 +191,74 @@ export const EditPlaylistForm = ({
             aria-checked={isPublic}
             aria-label="Toggle public visibility"
             className={`${styles.toggle} ${isPublic ? styles.toggleOn : ""}`}
-            onClick={() => setValue("is_public", !isPublic)}
+            onClick={() => {
+              const nextIsPublic = !isPublic;
+              setValue("is_public", nextIsPublic, {
+                shouldDirty: true,
+                shouldValidate: true,
+              });
+              if (!nextIsPublic) {
+                setValue("is_collaborative", false, {
+                  shouldDirty: true,
+                  shouldValidate: true,
+                });
+              }
+            }}
           >
             <span className={styles.toggleThumb} />
           </button>
 
-          <span aria-hidden="true">Collaborative</span>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={isCollaborative}
-            aria-label="Toggle collaborative mode"
-            className={`${styles.toggle} ${isCollaborative ? styles.toggleOn : ""}`}
-            onClick={() => setValue("is_collaborative", !isCollaborative)}
-          >
-            <span className={styles.toggleThumb} />
-          </button>
+          {isPublic && (
+            <>
+              <span aria-hidden="true">Collaborative</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={isCollaborative}
+                aria-label="Toggle collaborative mode"
+                className={`${styles.toggle} ${isCollaborative ? styles.toggleOn : ""}`}
+                onClick={() =>
+                  setValue("is_collaborative", !isCollaborative, {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                  })
+                }
+              >
+                <span className={styles.toggleThumb} />
+              </button>
+            </>
+          )}
         </div>
+
+        {errors.is_collaborative && (
+          <span className={styles.errorMessage} role="alert">
+            {errors.is_collaborative.message}
+          </span>
+        )}
 
         <div className={styles.editActions}>
           <button
             type="submit"
             className={styles.iconBtn}
-            disabled={isSaving || isCoverUploading}
+            disabled={isSaving || isSubmittingLocal || isCoverUploading}
             aria-label="Save playlist changes"
           >
             <IoCheckmarkOutline size={18} aria-hidden="true" />
-            {isSaving ? "Saving…" : "Save"}
+            {isSaving || isSubmittingLocal ? "Saving…" : "Save"}
           </button>
           <button
             type="button"
             className={styles.iconBtn}
-            onClick={onClose}
+            onClick={() => {
+              reset({
+                title: playlist.title,
+                description: playlist.description ?? "",
+                is_public: playlist.is_public,
+                is_collaborative: playlist.is_collaborative,
+                cover_art_url: playlist.cover_art_url ?? "",
+              });
+              onClose();
+            }}
             aria-label="Cancel editing"
           >
             <IoCloseOutline size={18} aria-hidden="true" />

--- a/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.tsx
+++ b/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.tsx
@@ -144,7 +144,9 @@ export const EditPlaylistForm = ({
             onClick={() => coverInputRef.current?.click()}
             disabled={isCoverUploading}
             aria-label={
-              isCoverUploading ? "Uploading cover image" : "Change playlist cover"
+              isCoverUploading
+                ? "Uploading cover image"
+                : "Change playlist cover"
             }
           >
             <IoImageOutline size={18} aria-hidden="true" />

--- a/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.tsx
+++ b/src/features/playlists/components/EditPlaylistForm/EditPlaylistForm.tsx
@@ -131,139 +131,141 @@ export const EditPlaylistForm = ({
         <AlertMessage message={editErrorMessage} />
       )}
 
-      <div className={styles.coverWrap}>
-        <img
-          src={coverUrl || "https://placehold.co/220"}
-          alt="Playlist cover art"
-          className={styles.coverArt}
-        />
-        <button
-          type="button"
-          className={styles.coverEditBtn}
-          onClick={() => coverInputRef.current?.click()}
-          disabled={isCoverUploading}
-          aria-label={
-            isCoverUploading ? "Uploading cover image" : "Change playlist cover"
-          }
-        >
-          <IoImageOutline size={18} aria-hidden="true" />
-          {isCoverUploading ? "Uploading…" : "Change cover"}
-        </button>
-        <input
-          ref={coverInputRef}
-          type="file"
-          accept="image/*"
-          className={styles.hiddenInput}
-          onChange={handleCoverChange}
-          aria-label="Upload cover image file"
-          tabIndex={-1}
-        />
-      </div>
-
-      <div className={styles.editFields}>
-        <div className={styles.fieldGroup}>
-          <input
-            className={styles.editInput}
-            {...register("title")}
-            placeholder="Title"
-            aria-label="Playlist title"
+      <div className={styles.editFormRow}>
+        <div className={styles.coverWrap}>
+          <img
+            src={coverUrl || "https://placehold.co/220"}
+            alt="Playlist cover art"
+            className={styles.coverArt}
           />
-          {errors.title && (
-            <span className={styles.errorMessage} role="alert">
-              {errors.title.message}
-            </span>
-          )}
-        </div>
-
-        <textarea
-          className={styles.editTextarea}
-          {...register("description")}
-          placeholder="Description"
-          rows={3}
-          aria-label="Playlist description"
-        />
-
-        <div className={styles.toggleRow}>
-          <span aria-hidden="true">Public</span>
           <button
             type="button"
-            role="switch"
-            aria-checked={isPublic}
-            aria-label="Toggle public visibility"
-            className={`${styles.toggle} ${isPublic ? styles.toggleOn : ""}`}
-            onClick={() => {
-              const nextIsPublic = !isPublic;
-              setValue("is_public", nextIsPublic, {
-                shouldDirty: true,
-                shouldValidate: true,
-              });
-              if (!nextIsPublic) {
-                setValue("is_collaborative", false, {
+            className={styles.coverEditBtn}
+            onClick={() => coverInputRef.current?.click()}
+            disabled={isCoverUploading}
+            aria-label={
+              isCoverUploading ? "Uploading cover image" : "Change playlist cover"
+            }
+          >
+            <IoImageOutline size={18} aria-hidden="true" />
+            {isCoverUploading ? "Uploading…" : "Change cover"}
+          </button>
+          <input
+            ref={coverInputRef}
+            type="file"
+            accept="image/*"
+            className={styles.hiddenInput}
+            onChange={handleCoverChange}
+            aria-label="Upload cover image file"
+            tabIndex={-1}
+          />
+        </div>
+
+        <div className={styles.editFields}>
+          <div className={styles.fieldGroup}>
+            <input
+              className={styles.editInput}
+              {...register("title")}
+              placeholder="Title"
+              aria-label="Playlist title"
+            />
+            {errors.title && (
+              <span className={styles.errorMessage} role="alert">
+                {errors.title.message}
+              </span>
+            )}
+          </div>
+
+          <textarea
+            className={styles.editTextarea}
+            {...register("description")}
+            placeholder="Description"
+            rows={3}
+            aria-label="Playlist description"
+          />
+
+          <div className={styles.toggleRow}>
+            <span aria-hidden="true">Public</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={isPublic}
+              aria-label="Toggle public visibility"
+              className={`${styles.toggle} ${isPublic ? styles.toggleOn : ""}`}
+              onClick={() => {
+                const nextIsPublic = !isPublic;
+                setValue("is_public", nextIsPublic, {
                   shouldDirty: true,
                   shouldValidate: true,
                 });
-              }
-            }}
-          >
-            <span className={styles.toggleThumb} />
-          </button>
-
-          {isPublic && (
-            <>
-              <span aria-hidden="true">Collaborative</span>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={isCollaborative}
-                aria-label="Toggle collaborative mode"
-                className={`${styles.toggle} ${isCollaborative ? styles.toggleOn : ""}`}
-                onClick={() =>
-                  setValue("is_collaborative", !isCollaborative, {
+                if (!nextIsPublic) {
+                  setValue("is_collaborative", false, {
                     shouldDirty: true,
                     shouldValidate: true,
-                  })
+                  });
                 }
-              >
-                <span className={styles.toggleThumb} />
-              </button>
-            </>
+              }}
+            >
+              <span className={styles.toggleThumb} />
+            </button>
+
+            {isPublic && (
+              <>
+                <span aria-hidden="true">Collaborative</span>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={isCollaborative}
+                  aria-label="Toggle collaborative mode"
+                  className={`${styles.toggle} ${isCollaborative ? styles.toggleOn : ""}`}
+                  onClick={() =>
+                    setValue("is_collaborative", !isCollaborative, {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
+                  }
+                >
+                  <span className={styles.toggleThumb} />
+                </button>
+              </>
+            )}
+          </div>
+
+          {errors.is_collaborative && (
+            <span className={styles.errorMessage} role="alert">
+              {errors.is_collaborative.message}
+            </span>
           )}
-        </div>
 
-        {errors.is_collaborative && (
-          <span className={styles.errorMessage} role="alert">
-            {errors.is_collaborative.message}
-          </span>
-        )}
-
-        <div className={styles.editActions}>
-          <button
-            type="submit"
-            className={styles.iconBtn}
-            disabled={isSaving || isSubmittingLocal || isCoverUploading}
-            aria-label="Save playlist changes"
-          >
-            <IoCheckmarkOutline size={18} aria-hidden="true" />
-            {isSaving || isSubmittingLocal ? "Saving…" : "Save"}
-          </button>
-          <button
-            type="button"
-            className={styles.iconBtn}
-            onClick={() => {
-              reset({
-                title: playlist.title,
-                description: playlist.description ?? "",
-                is_public: playlist.is_public,
-                is_collaborative: playlist.is_collaborative,
-                cover_art_url: playlist.cover_art_url ?? "",
-              });
-              onClose();
-            }}
-            aria-label="Cancel editing"
-          >
-            <IoCloseOutline size={18} aria-hidden="true" />
-            Cancel
-          </button>
+          <div className={styles.editActions}>
+            <button
+              type="submit"
+              className={styles.iconBtn}
+              disabled={isSaving || isSubmittingLocal || isCoverUploading}
+              aria-label="Save playlist changes"
+            >
+              <IoCheckmarkOutline size={18} aria-hidden="true" />
+              {isSaving || isSubmittingLocal ? "Saving…" : "Save"}
+            </button>
+            <button
+              type="button"
+              className={styles.iconBtn}
+              onClick={() => {
+                reset({
+                  title: playlist.title,
+                  description: playlist.description ?? "",
+                  is_public: playlist.is_public,
+                  is_collaborative: playlist.is_collaborative,
+                  cover_art_url: playlist.cover_art_url ?? "",
+                });
+                onClose();
+              }}
+              aria-label="Cancel editing"
+            >
+              <IoCloseOutline size={18} aria-hidden="true" />
+              Cancel
+            </button>
+          </div>
         </div>
       </div>
     </form>

--- a/src/features/playlists/components/EditPlaylistForm/schema.ts
+++ b/src/features/playlists/components/EditPlaylistForm/schema.ts
@@ -1,10 +1,16 @@
 import { z } from "zod";
 
-export const editPlaylistSchema = z.object({
-  title: z.string().min(1, "Title is required"),
-  description: z.string().optional(),
-  is_public: z.boolean(),
-  is_collaborative: z.boolean(),
-});
+export const editPlaylistSchema = z
+  .object({
+    title: z.string().min(1, "Title is required"),
+    description: z.string().optional(),
+    is_public: z.boolean(),
+    is_collaborative: z.boolean(),
+    cover_art_url: z.string().optional(),
+  })
+  .refine((data) => !(data.is_collaborative && !data.is_public), {
+    message: "Private playlists cannot be collaborative",
+    path: ["is_collaborative"],
+  });
 
 export type EditPlaylistFormValues = z.infer<typeof editPlaylistSchema>;

--- a/src/features/playlists/types.ts
+++ b/src/features/playlists/types.ts
@@ -18,7 +18,7 @@ export interface PlaylistOwner {
 export interface Playlist {
   id: number;
   title: string;
-  description: string;
+  description?: string;
   is_public: boolean;
   is_collaborative: boolean;
   cover_art_url: string | null;


### PR DESCRIPTION
## Changes made:
- Collaborative toggle now disabled (on the create playlist form) or not rendered at all (on the edit playlist form) when `public` is set to false.
- Decription type is set to `string | undefined` to reflect that it can be optional.
- CSS updated so that the Public toggle in EditPlaylistForm is aligned correctly when the Collaborative toggle is not rendered.
- The PlaylistEditForm is now correctly aligned next to the cover art instead of below it.

## Reasoning:
Not rendering the Collaborative toggle (editplaylistform) or disabling it (CreateNewPlaylistForm) ensures that users cannot accidentally try to make a private playlist collaborative, which is an extra guard against causing an API error. The `description` type used to be just 'string', which is inconsistent with the backend accepting blank data..